### PR TITLE
feat: implement audio buffer commit on PTT release (PAR-22)

### DIFF
--- a/app/lib/screens/ptt_screen.dart
+++ b/app/lib/screens/ptt_screen.dart
@@ -229,6 +229,7 @@ class _PTTScreenState extends State<PTTScreen> {
                             isEnabled: _isButtonAEnabled,
                             primaryColor: Colors.blue,
                             icon: Icons.mic,
+                            transportManager: _transportManager,
                           ),
                           const SizedBox(height: 8),
                           Text(
@@ -248,6 +249,7 @@ class _PTTScreenState extends State<PTTScreen> {
                             isEnabled: _isButtonBEnabled,
                             primaryColor: Colors.green,
                             icon: Icons.mic,
+                            transportManager: _transportManager,
                           ),
                           const SizedBox(height: 8),
                           Text(


### PR DESCRIPTION
## Summary
- Complete the PTT audio capture → send cycle by implementing input_audio_buffer.commit when PTT button is released
- Add audio PCM16 extraction from recorded WAV files  
- Add commitAudioBuffer() method to TransportManager for WebSocket audio buffer commit and response generation
- Integrate audio sending functionality with PTT buttons for end-to-end translation

## Key Changes
- **AudioService**: Add `getRecordedAudioAsPCM16()` method to extract PCM16 data from WAV recordings
- **TransportManager**: Add `commitAudioBuffer()` method that commits buffer and triggers response generation
- **PTTButton**: Modify to send captured audio and commit buffer on release via `_stopRecordingAndSend()`
- **PTTScreen**: Pass TransportManager instance to both PTT buttons for audio transmission

## Complete PTT Flow
1. **Press PTT** → Start audio recording
2. **Hold PTT** → Continue recording with visual feedback
3. **Release PTT** → Stop recording → Extract PCM16 data → Send to WebSocket → Commit buffer → Trigger translation

## Test Plan
- [x] Verify PTT button press starts audio recording
- [x] Verify PTT button release stops recording and sends audio data
- [x] Verify audio buffer commit triggers translation request
- [x] Verify no breaking changes to existing functionality
- [x] Pass Flutter analyzer checks
- [ ] Manual testing with actual OpenAI Realtime API connection
- [ ] Verify translation response handling

Fixes PAR-22

🤖 Generated with [Claude Code](https://claude.ai/code)